### PR TITLE
Fix player url error when v= is not first parameter in YT url

### DIFF
--- a/main.user.js
+++ b/main.user.js
@@ -133,7 +133,7 @@ function createIframe(newUrl) {
     const commonArgs = "autoplay=1&modestbranding=1";
     const params = extractParams(newUrl);
     if(newUrl.includes('&list')){
-        url = "https://www.youtube.com/nocookie.com/embed/" + params.videoId + "?" + commonArgs + "&list=" + params.playlistId + "&index=" + params.index;
+        url = "https://www.youtube-nocookie.com/embed/" + params.videoId + "?" + commonArgs + "&list=" + params.playlistId + "&index=" + params.index;
     } else {
         url = "https://www.youtube-nocookie.com/embed/" + params.videoId + "?" + commonArgs + getTimestampFromUrl(newUrl);
     }

--- a/main.user.js
+++ b/main.user.js
@@ -131,10 +131,11 @@ function bringToFront(target_id) {
 function createIframe(newUrl) {
     let url = "";
     const commonArgs = "autoplay=1&modestbranding=1";
+    const params = extractParams(newUrl);
     if(newUrl.includes('&list')){
-        url = "https://www.youtube-nocookie.com/embed/" + extractParams(newUrl).videoId + "?" + commonArgs + "&list=" + extractParams(newUrl).playlistId + "&index=" + extractParams(newUrl).index;
-    }else{
-        url = "https://www.youtube-nocookie.com/embed/" + splitUrl(newUrl) + "?" + commonArgs + getTimestampFromUrl(newUrl);
+        url = "https://www.youtube.com/nocookie.com/embed/" + params.videoId + "?" + commonArgs + "&list=" + params.playlistId + "&index=" + params.index;
+    } else {
+        url = "https://www.youtube-nocookie.com/embed/" + params.videoId + "?" + commonArgs + getTimestampFromUrl(newUrl);
     }
     console.log(url);
 


### PR DESCRIPTION
## Problem solved:
When ?v= is not the first parameter in the Youtube URL, it always takes the first parameter value as the video url.

An example with ?app=desktop :
![image](https://github.com/0belous/Youtube-AdBlock-ban-Bypass/assets/101000595/16cfaf49-3273-4e48-93b7-6d1753bc017b)
